### PR TITLE
Add missing signal handlers

### DIFF
--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -128,10 +128,14 @@ Page {
         target: FPDInterface
 
         onAdded: addLog(qsTr("Added finger %1").arg(finger))
+        onRemoved: addLog(qsTr("Removed finger: %1").arg(finger))
+        onIdentified: addLog(qsTr("Identified finger: %1").arg(finger))
+        onAborted: addLog(qsTr("Aborted"))
+        onFailed: addLog(qsTr("Failed"))
+        onVerified: addLog(qsTr("Verified"))
+
         onAcquisitionInfo: addLog(qsTr("Acqusition info: %1").arg(info))
         onErrorInfo: addLog(qsTr("Error: %1").arg(info))
-        onIdentified: addLog(qsTr("Identified finger: %1").arg(finger))
-        onRemoved: addLog(qsTr("Removed finger: %1").arg(finger))
         onFingerprintsChanged: updateFingers()
     }
 

--- a/src/fpdinterface.cpp
+++ b/src/fpdinterface.cpp
@@ -83,6 +83,9 @@ void FPDInterface::connectDaemon()
     connect(iface, SIGNAL(Added(const QString&)), this, SIGNAL(added(const QString&)), Qt::UniqueConnection);
     connect(iface, SIGNAL(Removed(const QString&)), this, SIGNAL(removed(const QString&)), Qt::UniqueConnection);
     connect(iface, SIGNAL(Identified(const QString&)), this, SIGNAL(identified(const QString&)), Qt::UniqueConnection);
+    connect(iface, SIGNAL(Aborted()), this, SIGNAL(aborted()), Qt::UniqueConnection);
+    connect(iface, SIGNAL(Failed()), this, SIGNAL(failed()), Qt::UniqueConnection);
+    connect(iface, SIGNAL(Verified()), this, SIGNAL(verified()), Qt::UniqueConnection);
 
     connect(iface, SIGNAL(StateChanged(const QString&)), this, SIGNAL(stateChanged(const QString&)), Qt::UniqueConnection);
     connect(iface, SIGNAL(EnrollProgressChanged(int)), this, SLOT(onEnrollProgress(int)), Qt::UniqueConnection);

--- a/src/fpdinterface.h
+++ b/src/fpdinterface.h
@@ -28,15 +28,19 @@ public:
 
 signals:
     void connectionStateChanged();
+    void fingerprintsChanged();
 
     void stateChanged(const QString &state);
     void enrollProgressChanged(int progress);
     void acquisitionInfo(const QString &info);
-    void errorInfo(const QString&);
+    void errorInfo(const QString &info);
+
     void added(const QString &finger);
-    void identified(const QString &finger);
     void removed(const QString &finger);
-    void fingerprintsChanged();
+    void identified(const QString &finger);
+    void aborted();
+    void failed();
+    void verified();
 
 public slots:
     int enroll(const QString &finger);

--- a/translations/sailfish-fpd-community-test-de.ts
+++ b/translations/sailfish-fpd-community-test-de.ts
@@ -110,6 +110,18 @@
         <source>Error while starting removal: %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Aborted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Verified</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>sailfish-fpd-community-test</name>

--- a/translations/sailfish-fpd-community-test.ts
+++ b/translations/sailfish-fpd-community-test.ts
@@ -110,6 +110,18 @@
         <source>Error while starting removal: %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Aborted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Verified</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>sailfish-fpd-community-test</name>


### PR DESCRIPTION
This adds missing signal handlers. It is expected to reduce the amount of puzzled looks while debugging the daemon. 

Please review